### PR TITLE
Removed extra argument line in optimization params

### DIFF
--- a/examples/hessian_timings/sdk/run.py
+++ b/examples/hessian_timings/sdk/run.py
@@ -64,7 +64,6 @@ job_params = {
         "optimization": {
             "params": {
                 "maxiter": 200,
-                "convergence": "strict",
                 "g_convergence": 1.0e-3,
             },
             "outputs": {"gradient": True, "vibrational_frequencies": True},


### PR DESCRIPTION
Extra argument line meant to demonstrate pydantic arg checking (intentionally caused failure) prevented successful submission of example. Removed the line. 