### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Python client.
 After doing this, in Python you can simply instantiate the Promethium Client
 directly in Python using:
 ```
-from promethium_sdk import PromethiumClient
+from promethium_sdk.client import PromethiumClient
 
 pc = PromethiumClient()
 ```


### PR DESCRIPTION
Kirk reported that the API seems to have an import error.  After pip installing (per the API key page's instructions), the tree in `site-packages` makes me think that this is the correct syntax.