### PR TITLE
Misc: path join, atom counts for xyz, remove bad conformers

### DIFF
--- a/examples/Getting_Started/01_Single_Point_Calculation/httpx/run.py
+++ b/examples/Getting_Started/01_Single_Point_Calculation/httpx/run.py
@@ -34,7 +34,8 @@ client = httpx.Client(base_url=base_url, headers=headers)
 # Specify the input xyz file contents and prepare (base64encode) for API submission
 # Molecule is Nirmatrelvir
 input_mol = base64.b64encode(
-    b"""
+    b"""67
+
     C        -3.61325       -0.84160        0.14457
     C        -2.25688       -0.64376       -0.57620
     F        -3.79613        0.10770        1.11447
@@ -151,7 +152,7 @@ if metadata:
 payload = job_params
 jobname = payload["name"]
 response = client.post("/v0/workflows", json=payload)
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print(f"Workflow {jobname} submitted with id: {workflow_id}")
@@ -166,7 +167,7 @@ workflow = wait_for_workflows_to_complete(
 
 # Get the status and Wall-clock time:
 response = client.get(f"v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
@@ -175,7 +176,7 @@ print(f"Workflow completed in {timetaken:.2f}s")
 
 # Extract and print the energy contained in the numeric results:
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 energy = response["results"]["rhf"]["energy"]
 print(f"Energy (Hartrees) = {energy}")
@@ -184,5 +185,5 @@ print(f"Energy (Hartrees) = {energy}")
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)

--- a/examples/Getting_Started/01_Single_Point_Calculation/sdk/run.py
+++ b/examples/Getting_Started/01_Single_Point_Calculation/sdk/run.py
@@ -23,7 +23,8 @@ if not os.path.exists(foldername):
 
 # Specify the input xyz file contents and prepare (base64encode) for API submission
 # Molecule is Nirmatrelvir
-input_mol = base64encode("""
+input_mol = base64encode("""67
+
     C        -3.61325       -0.84160        0.14457
     C        -2.25688       -0.64376       -0.57620
     F        -3.79613        0.10770        1.11447
@@ -137,7 +138,7 @@ print(f"Workflow completed in {spc_workflow.duration_seconds:.2f}s")
 
 # Obtain the numeric results:
 spc_results = prom.workflows.results(spc_workflow.id)
-with open(f"{foldername}/{spc_workflow.name}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{spc_workflow.name}_results.json"), "w") as fp:
     fp.write(spc_results.model_dump_json(indent=2))
 
 # Extract and print the energy contained in the numeric results:
@@ -145,5 +146,5 @@ energy = spc_results.results["rhf"]["energy"]
 print(f"Energy (Hartrees) = {energy}")
 
 # Download results:
-with open(f"{foldername}/{spc_workflow.name}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{spc_workflow.name}_results.zip"), "wb") as fp:
     fp.write(prom.workflows.download(spc_workflow.id))

--- a/examples/Getting_Started/02_Geometry_Optimization/httpx/run.py
+++ b/examples/Getting_Started/02_Geometry_Optimization/httpx/run.py
@@ -34,7 +34,8 @@ client = httpx.Client(base_url=base_url, headers=headers)
 # Specify the input xyz file contents and prepare (base64encode) for API submission
 # Molecule is Nirmatrelvir
 input_mol = base64.b64encode(
-    b"""
+    b"""67
+
     C        -3.61325       -0.84160        0.14457
     C        -2.25688       -0.64376       -0.57620
     F        -3.79613        0.10770        1.11447
@@ -165,12 +166,11 @@ if task_timeout:
 if metadata:
     job_params["metadata"] = metadata
 
-
 # submit a GO workflow using the above configuration
 payload = job_params
 jobname = payload["name"]
 response = client.post("/v0/workflows", json=payload)
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print(f"Workflow {jobname} submitted with id: {workflow_id}")
@@ -185,7 +185,7 @@ workflow = wait_for_workflows_to_complete(
 
 # Get the status and Wall-clock time:
 response = client.get(f"v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
@@ -194,7 +194,7 @@ print(f"Workflow completed in {timetaken:.2f}s")
 
 # Obtain the numeric results:
 response = client.get(f"/v0/workflows/{workflow_id}/results", headers=headers).json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 
 # Extract and print the energy contained in the numeric results:
@@ -210,5 +210,5 @@ print(f'{base64.b64decode(molecule_str).decode("utf-8")}')
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)

--- a/examples/Getting_Started/02_Geometry_Optimization/sdk/run.py
+++ b/examples/Getting_Started/02_Geometry_Optimization/sdk/run.py
@@ -23,7 +23,8 @@ if not os.path.exists(foldername):
 
 # Specify the input xyz file contents and prepare (base64encode) for API submission
 # Molecule is Nirmatrelvir
-input_mol = base64encode("""
+input_mol = base64encode("""67
+
     C        -3.61325       -0.84160        0.14457
     C        -2.25688       -0.64376       -0.57620
     F        -3.79613        0.10770        1.11447
@@ -165,7 +166,7 @@ print(f"Workflow completed in {go_workflow.duration_seconds:.2f}s")
 
 # Obtain the numeric results:
 go_results = prom.workflows.results(go_workflow.id)
-with open(f"{foldername}/{go_workflow.name}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{go_workflow.name}_results.json"), "w") as fp:
     fp.write(go_results.model_dump_json(indent=2))
 
 # Extract and print the energy contained in the numeric results:
@@ -178,5 +179,5 @@ print("The optimized geometry:")
 print(f'{molecule_str}')
 
 # Download results:
-with open(f"{foldername}/{go_workflow.name}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{go_workflow.name}_results.zip"), "wb") as fp:
     fp.write(prom.workflows.download(go_workflow.id))

--- a/examples/batch_conformer_search/sdk/run.py
+++ b/examples/batch_conformer_search/sdk/run.py
@@ -95,11 +95,9 @@ prom = PromethiumClient()
 
 SMILES = [
     "C1=CN=C(C=N1)C(=O)N",
-    "CC(=O)NC1=C(C(=C(C(=C1I)C(=O)O)I)NC(=O)C)I",
     "CC(=O)OC1=CC=CC=C1C(=O)O",
     "CCC(=C)C(=O)C1=C(C(=C(C=C1)OCC(=O)O)Cl)Cl",
     "CN1C(=O)CN=C(C2=C1C=CC(=C2)[N+](=O)[O-])C3=CC=CC=C3F",
-    "C(C(F)(F)F)(Cl)Br",
     "CCCC(C)(COC(=O)N)COC(=O)N",
     "CCCC(C)C1(C(=O)NC(=O)NC1=O)CC",
     "CCCC(C)C1(C(=O)NC(=O)NC1=O)CC=C",
@@ -140,7 +138,7 @@ for workflow_id in workflow_ids:
     print(f"Workflow completed in {workflow.duration_seconds:.2f}s")
 
     cs_results = prom.workflows.results(workflow_id)
-    with open(f"{foldername}/{workflow.name}_results.json", "w") as fp:
+    with open(os.path.join(foldername, f"{workflow.name}_results.json"), "w") as fp:
         fp.write(cs_results.model_dump_json(indent=2))
 
     # Get conformers:

--- a/examples/custom_conformer_search/sdk/run.py
+++ b/examples/custom_conformer_search/sdk/run.py
@@ -169,7 +169,7 @@ for workflow_id in workflow_ids:
     print(f"Workflow completed in {workflow.duration_seconds:.2f}s")
 
     cs_results = prom.workflows.results(workflow_id)
-    with open(f"{foldername}/{workflow.name}_results.json", "w") as fp:
+    with open(os.path.join(foldername, f"{workflow.name}_results.json"), "w") as fp:
         fp.write(cs_results.model_dump_json(indent=2))
 
     # Get conformers:

--- a/examples/fsapt/3acx/445/run.py
+++ b/examples/fsapt/3acx/445/run.py
@@ -15,7 +15,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 monomerA = base64encode(
-"""
+"""406
+
 C                    55.520000000000     8.935000000000    30.847000000000
 H                    56.439000000000     8.682000000000    30.314000000000
 H                    54.997000000000     9.727000000000    30.312000000000
@@ -426,7 +427,8 @@ H                    57.769000000000    -7.216000000000    46.812000000000
 )
 
 monomerB = base64encode(
-"""
+"""39
+
 C  56.282 16.378 57.621
 C  56.834 15.837 56.524
 C  58.279 22.417 53.598
@@ -470,10 +472,10 @@ H  54.103 10.878 53.251
 )
 
 job_params = {
-  "name": "fsapt-test",
-  "version": "v1",
-  "kind": "FSAPTCalculation",
-  "parameters": {
+    "name": "fsapt-test",
+    "version": "v1",
+    "kind": "FSAPTCalculation",
+    "parameters": {
         "molecule_a": {
             "base64data": monomerA,
             "filetype": "xyz",
@@ -508,11 +510,11 @@ job_params = {
                 "g_convergence": 1.0e-6
             }
         }
-  },
-  "resources": {
-    "gpu_type": "a100",
-    "gpu_count": 1
-  }
+    },
+    "resources": {
+        "gpu_type": "a100",
+        "gpu_count": 1
+    }
 }
 
 headers = {
@@ -528,7 +530,7 @@ jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload)
 response.raise_for_status()
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -542,20 +544,20 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"/v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
@@ -573,4 +575,3 @@ print('')
 print('    Elst     Exch    IndAB    IndBA     Disp    Total')
 print('%8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % (Eelst, Eexch, EindAB, EindBA, Edisp, Esapt))
 print('')
-

--- a/examples/fsapt/3acx/445_numerical/run.py
+++ b/examples/fsapt/3acx/445_numerical/run.py
@@ -15,7 +15,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 monomerA = base64encode(
-"""
+"""406
+
 C                    55.520000000000     8.935000000000    30.847000000000
 H                    56.439000000000     8.682000000000    30.314000000000
 H                    54.997000000000     9.727000000000    30.312000000000
@@ -426,7 +427,8 @@ H                    57.769000000000    -7.216000000000    46.812000000000
 )
 
 monomerB = base64encode(
-"""
+"""39
+
 C  56.282 16.378 57.621
 C  56.834 15.837 56.524
 C  58.279 22.417 53.598
@@ -470,49 +472,49 @@ H  54.103 10.878 53.251
 )
 
 job_params = {
-  "name": "fsapt-test",
-  "version": "v1",
-  "kind": "FSAPTCalculation",
-  "parameters": {
-        "molecule_a": {
-            "base64data": monomerA,
-            "filetype": "xyz",
-            "params": {
-                "charge": 0,
+    "name": "fsapt-test",
+    "version": "v1",
+    "kind": "FSAPTCalculation",
+    "parameters": {
+            "molecule_a": {
+                "base64data": monomerA,
+                "filetype": "xyz",
+                "params": {
+                    "charge": 0,
+                }
+            },
+            "molecule_b": {
+                "base64data": monomerB,
+                "filetype": "xyz",
+                "params": {
+                    "charge": 0,
+                }
+            },
+            "system": {
+                "params": {
+                    "methodname": "hf",
+                    "basisname": "jun-cc-pvdz",
+                    "jkfit_basisname": "jun-cc-pvdz-jkfit",
+                    "k_grid_scheme": "GRID1",
+                    "threshold_pq": 1e-12
+                }
+            },
+            "jk_builder": {
+#                "type": "core_dfjk",
+#                "type": "dfj_grid_k",
+                "type": "numerical_jk",
+                "params": {}
+            },
+            "hf": {
+                "params": {
+                    "g_convergence": 1.0e-6
+                }
             }
-        },
-        "molecule_b": {
-            "base64data": monomerB,
-            "filetype": "xyz",
-            "params": {
-                "charge": 0,
-            }
-        },
-        "system": {
-            "params": {
-                "methodname": "hf",
-                "basisname": "jun-cc-pvdz",
-                "jkfit_basisname": "jun-cc-pvdz-jkfit",
-                "k_grid_scheme": "GRID1",
-                "threshold_pq": 1e-12
-            }
-        },
-        "jk_builder": {
-#            "type": "core_dfjk",
-#            "type": "dfj_grid_k",
-            "type": "numerical_jk",
-            "params": {}
-        },
-        "hf": {
-            "params": {
-                "g_convergence": 1.0e-6
-            }
-        }
-  },
-  "resources": {
-    "gpu_type": "a100",
-    "gpu_count": 1
-  }
+    },
+    "resources": {
+        "gpu_type": "a100",
+        "gpu_count": 1
+    }
 }
 
 headers = {
@@ -528,7 +530,7 @@ jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload)
 response.raise_for_status()
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -542,20 +544,20 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"/v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
@@ -573,4 +575,3 @@ print('')
 print('    Elst     Exch    IndAB    IndBA     Disp    Total')
 print('%8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % (Eelst, Eexch, EindAB, EindBA, Edisp, Esapt))
 print('')
-

--- a/examples/fsapt/3acx/83/run.py
+++ b/examples/fsapt/3acx/83/run.py
@@ -15,7 +15,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 monomerA = base64encode(
-"""
+"""44
+
 C  48.671 21.557 53.684
 H  47.823 22.241 53.598
 H  48.289 20.572 53.954
@@ -64,7 +65,8 @@ H  54.499 21.450 45.203
 )
 
 monomerB = base64encode(
-"""
+"""39
+
 C  56.282 16.378 57.621
 C  56.834 15.837 56.524
 C  58.279 22.417 53.598
@@ -108,10 +110,10 @@ H  54.103 10.878 53.251
 )
 
 job_params = {
-  "name": "fsapt-test",
-  "version": "v1",
-  "kind": "FSAPTCalculation",
-  "parameters": {
+    "name": "fsapt-test",
+    "version": "v1",
+    "kind": "FSAPTCalculation",
+    "parameters": {
         "molecule_a": {
             "base64data": monomerA,
             "filetype": "xyz",
@@ -146,11 +148,11 @@ job_params = {
                 "g_convergence": 1.0e-6
             }
         }
-  },
-  "resources": {
-    "gpu_type": "a100",
-    "gpu_count": 1
-  }
+    },
+    "resources": {
+        "gpu_type": "a100",
+        "gpu_count": 1
+    }
 }
 
 headers = {
@@ -166,7 +168,7 @@ jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload)
 response.raise_for_status()
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -180,20 +182,20 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"/v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
@@ -211,4 +213,3 @@ print('')
 print('    Elst     Exch    IndAB    IndBA     Disp    Total')
 print('%8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % (Eelst, Eexch, EindAB, EindBA, Edisp, Esapt))
 print('')
-

--- a/examples/fsapt/7kw4/run.py
+++ b/examples/fsapt/7kw4/run.py
@@ -20,7 +20,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 monomerA = base64encode(
-"""
+"""45
+
  N         10.11700000         17.00600000         16.77600000
  N          9.99600000         22.94800000          7.85200000
  C          8.64600000         22.28100000          9.62500000
@@ -76,7 +77,8 @@ for idx in range(len(fragsA)):
     labelsA.append('A%d' % (idx+1))
 
 monomerB = base64encode(
-"""
+"""780
+
  O         20.75000000         34.93000000         23.60400000
  C         20.02200000         33.72700000         23.79800000
  C         20.99200000         32.58100000         23.67700000
@@ -872,10 +874,10 @@ for idx in range(len(fragsB)):
     labelsB.append('B%d' % (idx+1))
 
 job_params = {
-  "name": "fsapt-test",
-  "version": "v1",
-  "kind": "FSAPTCalculation",
-  "parameters": {
+    "name": "fsapt-test",
+    "version": "v1",
+    "kind": "FSAPTCalculation",
+    "parameters": {
         "molecule_a": {
             "base64data": monomerA,
             "filetype": "xyz",
@@ -912,11 +914,11 @@ job_params = {
                 "g_convergence": 1.0e-6
             }
         }
-  },
-  "resources": {
-    "gpu_type": gpu_type,
-    "gpu_count": 1
-  }
+    },
+    "resources": {
+        "gpu_type": gpu_type,
+        "gpu_count": 1
+    }
 }
 
 headers = {
@@ -932,7 +934,7 @@ jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload)
 response.raise_for_status()
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -946,20 +948,20 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"/v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
@@ -989,4 +991,3 @@ for i in range(len(labels_b)):
     print('%-9s %-9s %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % ('All', labels_b[i], np.sum(Eelst, axis=0)[i], np.sum(Eexch, axis=0)[i], np.sum(EindAB, axis=0)[i], np.sum(EindBA, axis=0)[i], np.sum(Edisp, axis=0)[i], np.sum(Esapt, axis=0)[i]))
 
 print('%-9s %-9s %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % ('All', 'All', np.sum(Eelst), np.sum(Eexch), np.sum(EindAB), np.sum(EindBA), np.sum(Edisp), np.sum(Esapt)))
-

--- a/examples/fsapt/fsapt-test/httpx/run.py
+++ b/examples/fsapt/fsapt-test/httpx/run.py
@@ -20,7 +20,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 monomerA = base64encode(
-"""
+"""11
+
  C   -3.794947367454    0.447388712628    1.782117979176
  H   -3.116947367454    0.417388712628    0.936117979176
  C   -3.079947367454   -0.189611287372    2.980117979176
@@ -36,7 +37,8 @@ monomerA = base64encode(
 )
 
 monomerB = base64encode(
-"""
+"""18
+
  C    1.557052632546   -0.992611287372   -2.697882020824
  O    1.911052632546   -1.970611287372   -2.060882020824
  N    1.133052632546    0.132388712628   -2.093882020824
@@ -59,10 +61,10 @@ monomerB = base64encode(
 )
 
 job_params = {
-  "name": "fsapt-test",
-  "version": "v1",
-  "kind": "FSAPTCalculation",
-  "parameters": {
+    "name": "fsapt-test",
+    "version": "v1",
+    "kind": "FSAPTCalculation",
+    "parameters": {
         "molecule_a": {
             "base64data": monomerA,
             "filetype": "xyz",
@@ -99,11 +101,11 @@ job_params = {
                 "g_convergence": 1.0e-6
             }
         }
-  },
-  "resources": {
-    "gpu_type": gpu_type,
-    "gpu_count": 1
-  }
+    },
+    "resources": {
+        "gpu_type": gpu_type,
+        "gpu_count": 1
+    }
 }
 
 headers = {
@@ -119,7 +121,7 @@ jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload)
 response.raise_for_status()
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -133,20 +135,20 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"/v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
@@ -176,4 +178,3 @@ for i in range(len(labels_b)):
     print('%-9s %-9s %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % ('All', labels_b[i], np.sum(Eelst, axis=0)[i], np.sum(Eexch, axis=0)[i], np.sum(EindAB, axis=0)[i], np.sum(EindBA, axis=0)[i], np.sum(Edisp, axis=0)[i], np.sum(Esapt, axis=0)[i]))
 
 print('%-9s %-9s %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % ('All', 'All', np.sum(Eelst), np.sum(Eexch), np.sum(EindAB), np.sum(EindBA), np.sum(Edisp), np.sum(Esapt)))
-

--- a/examples/fsapt/fsapt-test/sdk/run.py
+++ b/examples/fsapt/fsapt-test/sdk/run.py
@@ -26,7 +26,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 monomerA = base64encode(
-"""
+"""11
+
  C   -3.794947367454    0.447388712628    1.782117979176
  H   -3.116947367454    0.417388712628    0.936117979176
  C   -3.079947367454   -0.189611287372    2.980117979176
@@ -42,7 +43,8 @@ monomerA = base64encode(
 )
 
 monomerB = base64encode(
-"""
+"""18
+
  C    1.557052632546   -0.992611287372   -2.697882020824
  O    1.911052632546   -1.970611287372   -2.060882020824
  N    1.133052632546    0.132388712628   -2.093882020824
@@ -66,10 +68,10 @@ monomerB = base64encode(
 
 wf_name = "fsapt-test"
 fsapt_wf = CreateFSAPTCalculationWorkflowRequest(**{
-  "name": wf_name,
-  "version": "v1",
-  "kind": "FSAPTCalculation",
-  "parameters": {
+    "name": wf_name,
+    "version": "v1",
+    "kind": "FSAPTCalculation",
+    "parameters": {
         "molecule_a": {
             "base64data": monomerA,
             "filetype": "xyz",
@@ -106,21 +108,21 @@ fsapt_wf = CreateFSAPTCalculationWorkflowRequest(**{
                 "g_convergence": 1.0e-6
             }
         }
-  },
-  "resources": {
-    "gpu_type": gpu_type,
-    "gpu_count": 1
-  }
+    },
+    "resources": {
+        "gpu_type": gpu_type,
+        "gpu_count": 1
+    }
 })
 
 prom = PromethiumClient()
 workflow = prom.workflows.submit(fsapt_wf)
+print(f"Workflow {workflow.name} submitted with id: {workflow.id}")
 prom.workflows.wait(workflow.id)
 
 workflow = prom.workflows.get(workflow.id)
 print(f"Workflow {workflow.name} completed with status: {workflow.status}")
 print(f"Workflow completed in {workflow.duration_seconds:.2f}s")
-
 
 response = prom.workflows.results(workflow.id).model_dump()
 labels_a = response['results']['fsapt']['fragment_labels']['molecule_a']
@@ -148,4 +150,3 @@ for i in range(len(labels_b)):
     print('%-9s %-9s %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % ('All', labels_b[i], np.sum(Eelst, axis=0)[i], np.sum(Eexch, axis=0)[i], np.sum(EindAB, axis=0)[i], np.sum(EindBA, axis=0)[i], np.sum(Edisp, axis=0)[i], np.sum(Esapt, axis=0)[i]))
 
 print('%-9s %-9s %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf %8.3lf' % ('All', 'All', np.sum(Eelst), np.sum(Eexch), np.sum(EindAB), np.sum(EindBA), np.sum(Edisp), np.sum(Esapt)))
-

--- a/examples/hessian_timings/httpx/run.py
+++ b/examples/hessian_timings/httpx/run.py
@@ -15,7 +15,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 mol = base64encode(
-"""
+"""9
+
     O           -1.510407226976     0.757898746844     0.000000000000
     O           -0.553334234073    -1.306832947272     0.000000000000
     C            0.851836372408     0.670262334922     0.000000000000
@@ -75,7 +76,7 @@ payload = job_params
 jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload)
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -89,14 +90,14 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"/v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 energy = response["results"]["optimization"]["energy"]
 print(energy)
@@ -104,5 +105,5 @@ print(energy)
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)

--- a/examples/hessian_timings/sdk/run.py
+++ b/examples/hessian_timings/sdk/run.py
@@ -13,7 +13,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 mol = base64encode(
-"""
+"""9
+
     O           -1.510407226976     0.757898746844     0.000000000000
     O           -0.553334234073    -1.306832947272     0.000000000000
     C            0.851836372408     0.670262334922     0.000000000000
@@ -83,7 +84,7 @@ print(f"Workflow {workflow.name} completed with status: {workflow.status}")
 print(f"Workflow completed in {workflow.duration_seconds:.2f}s")
 
 go_results = prom.workflows.results(workflow.id)
-with open(f"{foldername}/{workflow.name}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{workflow.name}_results.json"), "w") as fp:
     fp.write(go_results.model_dump_json(indent=2))
 
 # Numeric results:
@@ -91,5 +92,5 @@ energy = go_results.results["optimization"]["energy"]
 print(energy)
 
 # Download:
-with open(f"{foldername}/{workflow.name}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{workflow.name}_results.zip"), "wb") as fp:
     fp.write(prom.workflows.download(workflow.id))

--- a/examples/interaction_energy/sdk/run.py
+++ b/examples/interaction_energy/sdk/run.py
@@ -143,5 +143,5 @@ print(f"CP-Corrected Interaction Energy:  {cp_corrected_interaction_energy}")
 print(f"Basis Set Superposition Error:    {basis_set_superposition_error}")
 
 # Download:
-with open(f"{foldername}/{workflow.name}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{workflow.name}_results.zip"), "wb") as fp:
     fp.write(prom.workflows.download(workflow.id))

--- a/examples/reaction_paths/sdk/run.py
+++ b/examples/reaction_paths/sdk/run.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 from promethium_sdk.client import PromethiumClient
 from promethium_sdk.models import (
@@ -10,9 +11,7 @@ from promethium_sdk.utils import (
 
 foldername = "output"
 gpu_type = os.getenv("PM_GPU_TYPE", "a100")
-dir_path = os.path.abspath(
-    os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
-)
+dir_path = pathlib.Path(__file__).parent.parent.resolve()
 
 if not os.path.exists(foldername):
     os.makedirs(foldername)
@@ -23,9 +22,9 @@ workflow_ids = []
 prom = PromethiumClient()
 
 for i in range(1, n + 1):
-    with open(os.path.join(dir_path, f"{i}/reactant.xyz"), "r") as fp:
+    with open(os.path.join(dir_path, str(i), "reactant.xyz"), "r") as fp:
         reactant = base64encode(fp.read())
-    with open(os.path.join(dir_path, f"{i}/product.xyz"), "r") as fp:
+    with open(os.path.join(dir_path, str(i), "product.xyz"), "r") as fp:
         product = base64encode(fp.read())
 
     job_params = {
@@ -112,9 +111,9 @@ for i, workflow_id in enumerate(workflow_ids):
     print(f"Workflow completed in {workflow.duration_seconds:.2f}s")
 
     workflow_results = prom.workflows.results(workflow.id)
-    with open(f"{foldername}/{i}_{workflow.name}_results.json", "w") as fp:
+    with open(os.path.join(foldername, f"{i}_{workflow.name}_results.json"), "w") as fp:
         fp.write(workflow_results.model_dump_json(indent=2))
 
     # Download:
-    with open(f"{foldername}/{i}_{workflow.name}_results.zip", "wb") as fp:
+    with open(os.path.join(foldername, f"{i}_{workflow.name}_results.zip"), "wb") as fp:
         fp.write(prom.workflows.download(workflow.id))

--- a/examples/results_parsing/sdk/run.py
+++ b/examples/results_parsing/sdk/run.py
@@ -69,7 +69,7 @@ print(f"Workflow {go_workflow.name} completed with status: {go_workflow.status}"
 print(f"Workflow completed in {go_workflow.duration_seconds:.2f}s")
 
 go_results = prom.workflows.results(go_workflow.id)
-with open(f"{OUTPUT_FOLDER}/{go_workflow.name}_results.json", "w") as fp:
+with open(os.path.join(OUTPUT_FOLDER, f"{go_workflow.name}_results.json"), "w") as fp:
     fp.write(go_results.model_dump_json(indent=2))
 
 # Numeric results:
@@ -80,12 +80,13 @@ molecule_str = go_results.get_artifact("optimized-molecule")
 # Download to ZIP, save to file, and extract the contents.
 
 # Write the ZIP file to disk:
-with open(f"{OUTPUT_FOLDER}/example-results.zip", "wb") as fp:
+zipfile_path = os.path.join(OUTPUT_FOLDER, "example-results.zip")
+with open(zipfile_path, "wb") as fp:
     fp.write(prom.workflows.download(go_workflow.id))
 
 # Unzip the downloaded file to a folder:
 unzip_folder = os.path.join(OUTPUT_FOLDER, go_workflow.name)
-with zipfile.ZipFile(f"{OUTPUT_FOLDER}/example-results.zip", "r") as zip_ref:
+with zipfile.ZipFile(zipfile_path, "r") as zip_ref:
     # Extract the contents to a folder, and write all individual files to disk:
     zip_ref.extractall(unzip_folder)
     # List all of the files in the archive:

--- a/examples/scf_properties/atomic_charges/httpx/run.py
+++ b/examples/scf_properties/atomic_charges/httpx/run.py
@@ -80,7 +80,7 @@ if metadata:
 payload = job_params
 jobname = payload["name"]
 response = client.post("/v0/workflows", json=payload)
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print(f"Workflow {jobname} submitted with id: {workflow_id}")
@@ -95,7 +95,7 @@ workflow = wait_for_workflows_to_complete(
 
 # Get the status and Wall-clock time:
 response = client.get(f"v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
@@ -106,12 +106,12 @@ print(f"Workflow completed in {timetaken:.2f}s")
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)
 
 # Extract and print the atomic charges contained in the numeric results:
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 atomic_charges = response["results"]["scf_properties"]["atomic_charges"]
 analysis_methods = [data["analysis_method"] for data in atomic_charges]

--- a/examples/scf_properties/atomic_charges/sdk/run.py
+++ b/examples/scf_properties/atomic_charges/sdk/run.py
@@ -67,11 +67,11 @@ print(f"Workflow {spc_workflow.name} completed with status: {spc_workflow.status
 print(f"Workflow completed in {spc_workflow.duration_seconds:.2f}s")
 
 spc_results = prom.workflows.results(spc_workflow.id)
-with open(f"{foldername}/{spc_workflow.name}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{spc_workflow.name}_results.json"), "w") as fp:
     fp.write(spc_results.model_dump_json(indent=2))
 
 # Download results:
-with open(f"{foldername}/{spc_workflow.name}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{spc_workflow.name}_results.zip"), "wb") as fp:
     fp.write(prom.workflows.download(spc_workflow.id))
 
 # Extract and print the atomic charges contained in the numeric results:

--- a/examples/scf_properties/batch/httpx/run.py
+++ b/examples/scf_properties/batch/httpx/run.py
@@ -76,7 +76,7 @@ for file in os.listdir(molecules_dir):
     payload = job_params
     jobname = payload["name"]
     response = client.post("/v0/workflows", json=payload)
-    with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+    with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
         fp.write(json.dumps(response.json()))
     workflow_id = response.json()["id"]
     print(f"Workflow {jobname} submitted with id: {workflow_id}")
@@ -98,7 +98,7 @@ for mol_workflow_id in molecule_workflow_ids.items():
 
     # Get the status and Wall-clock time:
     response = client.get(f"v0/workflows/{workflow_id}").json()
-    with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+    with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
         fp.write(json.dumps(response))
     name = response["name"]
     timetaken = response["duration_seconds"]
@@ -108,12 +108,12 @@ for mol_workflow_id in molecule_workflow_ids.items():
     response = client.get(
         f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
     )
-    with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+    with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
         fp.write(response.content)
 
     # Extract and collect the SCF properties contained in the numeric results:
     response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-    with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+    with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
         fp.write(json.dumps(response))
 
     molecule_names.append(mol_name)

--- a/examples/scf_properties/batch/sdk/run.py
+++ b/examples/scf_properties/batch/sdk/run.py
@@ -71,13 +71,13 @@ for mol_workflow_id in molecule_workflow_ids.items():
     print(f"Workflow {workflow.name} completed with status {workflow.status} in {workflow.duration_seconds:.2f}s")
 
     workflow_results = prom.workflows.results(workflow.id)
-    with open(f"{foldername}/{workflow.name}_results.json", "w") as fp:
+    with open(os.path.join(foldername, f"{workflow.name}_results.json"), "w") as fp:
         fp.write(workflow_results.model_dump_json(indent=2))
 
     molecule_names.append(mol_name)
     molecule_scf_properties.append(workflow_results.results["scf_properties"])
 
-    with open(f"{foldername}/{workflow.name}_results.zip", "wb") as fp:
+    with open(os.path.join(foldername, f"{workflow.name}_results.zip"), "wb") as fp:
         fp.write(prom.workflows.download(workflow.id))
 
 # Print a table of the SCF properties for each molecule.

--- a/examples/sequential_GO_to_SPC/httpx/run.py
+++ b/examples/sequential_GO_to_SPC/httpx/run.py
@@ -17,7 +17,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 mol = base64encode(
-"""
+"""67
+
     C        -3.61325       -0.84160        0.14457
     C        -2.25688       -0.64376       -0.57620
     F        -3.79613        0.10770        1.11447
@@ -133,7 +134,7 @@ payload = job_params
 jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload, headers=headers)
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -147,14 +148,14 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"/v0/workflows/{workflow_id}", headers=headers).json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results", headers=headers).json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 energy = response["results"]["optimization"]["energy"]
 mol = response["results"]["artifacts"]["optimized-molecule"]["base64data"]
@@ -164,7 +165,7 @@ print(base64decode(mol))
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)
 
 job_params = {
@@ -205,7 +206,7 @@ payload = job_params
 jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload)
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -219,14 +220,14 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 energy = response["results"]["rhf"]["energy"]
 print(energy)
@@ -234,5 +235,5 @@ print(energy)
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)

--- a/examples/sequential_GO_to_SPC/sdk/run.py
+++ b/examples/sequential_GO_to_SPC/sdk/run.py
@@ -13,7 +13,8 @@ gpu_type = os.getenv("PM_GPU_TYPE", "a100")
 if not os.path.exists(foldername):
     os.makedirs(foldername)
 
-mol = base64encode("""
+mol = base64encode("""67
+
     C        -3.61325       -0.84160        0.14457
     C        -2.25688       -0.64376       -0.57620
     F        -3.79613        0.10770        1.11447
@@ -120,7 +121,9 @@ job_params = {
 
 prom = PromethiumClient()
 go_payload = CreateGeometryOptimizationWorkflowRequest(**job_params)
+print(f"Submitting {go_name}...", end="")
 go_workflow = prom.workflows.submit(go_payload)
+print("done!")
 
 prom.workflows.wait(go_workflow.id)
 
@@ -129,7 +132,7 @@ print(f"Workflow {go_workflow.name} completed with status: {go_workflow.status}"
 print(f"Workflow completed in {go_workflow.duration_seconds:.2f}s")
 
 go_results = prom.workflows.results(go_workflow.id)
-with open(f"{foldername}/{go_workflow.name}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{go_workflow.name}_results.json"), "w") as fp:
     fp.write(go_results.model_dump_json(indent=2))
 
 # Numeric results:
@@ -183,6 +186,7 @@ job_params = {
 spc_payload = CreateSinglePointCalculationWorkflowRequest(**job_params)
 print(f"Submitting {spc_name}...", end="")
 spc_workflow = prom.workflows.submit(spc_payload)
+print("done!")
 
 prom.workflows.wait(spc_workflow.id)
 
@@ -191,7 +195,7 @@ print(f"Workflow {spc_workflow.name} completed with status: {spc_workflow.status
 print(f"Workflow completed in {spc_workflow.duration_seconds:.2f}s")
 
 spc_results = prom.workflows.results(spc_workflow.id)
-with open(f"{foldername}/{spc_workflow.name}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{spc_workflow.name}_results.json"), "w") as fp:
     fp.write(spc_results.model_dump_json(indent=2))
 
 # Numeric results:
@@ -199,5 +203,5 @@ energy = spc_results.results["rhf"]["energy"]
 print(energy)
 
 # Download:
-with open(f"{foldername}/{spc_workflow.name}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{spc_workflow.name}_results.zip"), "wb") as fp:
     fp.write(prom.workflows.download(spc_results.id))

--- a/examples/ts_endpoints_demo/httpx/run.py
+++ b/examples/ts_endpoints_demo/httpx/run.py
@@ -15,7 +15,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 reactant = base64encode(
-"""
+"""12
+
  C 0.797293840 1.081303780 -0.164555970
  C -0.547182890 0.998873790 0.574238880
  H -0.395761920 0.541241890 1.549831680
@@ -32,7 +33,8 @@ reactant = base64encode(
 )
 
 product = base64encode(
-"""
+"""12
+
  C -1.480477590 0.370142220 -0.164123070
  C -0.251557300 1.224758920 0.164042060
  H 0.085104930 1.819910830 -0.680028190
@@ -126,7 +128,7 @@ payload = job_params
 jobname = payload["name"]
 print(f"Submitting {jobname}...", end="")
 response = client.post("/v0/workflows", json=payload)
-with open(f"{foldername}/{jobname}_submitted.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_submitted.json"), "w") as fp:
     fp.write(json.dumps(response.json()))
 workflow_id = response.json()["id"]
 print("done!")
@@ -140,18 +142,18 @@ workflow = wait_for_workflows_to_complete(
 print(f"Workflow completed with status: {workflow['status']}")
 
 response = client.get(f"/v0/workflows/{workflow_id}").json()
-with open(f"{foldername}/{jobname}_status.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_status.json"), "w") as fp:
     fp.write(json.dumps(response))
 name = response["name"]
 timetaken = response["duration_seconds"]
 print(f"Name: {name}, time taken: {timetaken:.2f}s")
 
 response = client.get(f"/v0/workflows/{workflow_id}/results").json()
-with open(f"{foldername}/{jobname}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.json"), "w") as fp:
     fp.write(json.dumps(response))
 
 response = client.get(
     f"/v0/workflows/{workflow_id}/results/download", follow_redirects=True
 )
-with open(f"{foldername}/{jobname}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{jobname}_results.zip"), "wb") as fp:
     fp.write(response.content)

--- a/examples/ts_endpoints_demo/sdk/run.py
+++ b/examples/ts_endpoints_demo/sdk/run.py
@@ -13,7 +13,8 @@ if not os.path.exists(foldername):
     os.makedirs(foldername)
 
 reactant = base64encode(
-"""
+"""12
+
  C 0.797293840 1.081303780 -0.164555970
  C -0.547182890 0.998873790 0.574238880
  H -0.395761920 0.541241890 1.549831680
@@ -30,7 +31,8 @@ reactant = base64encode(
 )
 
 product = base64encode(
-"""
+"""12
+
  C -1.480477590 0.370142220 -0.164123070
  C -0.251557300 1.224758920 0.164042060
  H 0.085104930 1.819910830 -0.680028190
@@ -124,7 +126,7 @@ print(f"Workflow {workflow.name} completed with status: {workflow.status}")
 print(f"Workflow completed in {workflow.duration_seconds:.2f}s")
 
 tsofe_results = prom.workflows.results(workflow.id)
-with open(f"{foldername}/{workflow.name}_results.json", "w") as fp:
+with open(os.path.join(foldername, f"{workflow.name}_results.json"), "w") as fp:
     fp.write(tsofe_results.model_dump_json(indent=2))
 
 # Optimized molecule:
@@ -132,5 +134,5 @@ optimized_molecule = tsofe_results.get_artifact("optimized-molecule")
 print(optimized_molecule)
 
 # Download:
-with open(f"{foldername}/{workflow.name}_results.zip", "wb") as fp:
+with open(os.path.join(foldername, f"{workflow.name}_results.zip"), "wb") as fp:
     fp.write(prom.workflows.download(workflow.id))


### PR DESCRIPTION
Miscellaneous edits/fixes:

- Favor using os.path.join instead of concatenating the paths
- Add missing atom counts in XYZ file usage
- Remove conformers failing validation